### PR TITLE
changes to qs-autoscale-main.flat.template.yaml

### DIFF
--- a/templates/qs-autoscale-main.flat.template.yaml
+++ b/templates/qs-autoscale-main.flat.template.yaml
@@ -54,7 +54,7 @@ Metadata:
           - ELBType
           - ELBClients
           - ELBPort
-          - ShellSecurityGatewayStack
+          - ShellSecurityGatewayServer
 
       - Label:
           default: Check Point CloudGuard IaaS Security Management Server Configuration
@@ -78,8 +78,8 @@ Metadata:
           - PrimaryManagement
           - STSRoles
           - TrustedAccount
-          - ManagementStackVolumeSize
-          - ShellManagementStack
+          - ManagementServerVolumeSize
+          - ShellManagementServer
       - Label:
           default: Web Servers Auto Scaling Group Configuration
         Parameters:
@@ -212,7 +212,7 @@ Metadata:
         default: Instance Name
       ServersMinSize:
         default: Minimum group size
-      ServerMaxSize:
+      ServersMaxSize:
         default: Maximum group size
       ServersTargetGroups:
         default: Target Groups
@@ -220,7 +220,7 @@ Metadata:
         default: Source Security Group
       TrustedAccount:
         default: Trusted Account ID
-      ManagementStackVolumeSize:
+      ManagementServerVolumeSize:
         default: Management Volume Size
       SecurityGatewayVolumeSize:
         default: Security Gateway Volume Size
@@ -237,7 +237,6 @@ Parameters:
   AvailabilityZones:
     Description: 'List of Availability Zones (AZs) to use for the subnets in the VPC. Select at least two'
     Type: List<AWS::EC2::AvailabilityZone::Name>
-    MinLength: 2
   NumberOfAZs:
     Description: 'Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter.  Default: 2'
     Type: Number
@@ -301,7 +300,6 @@ Parameters:
   KeyName:
     Description: 'The EC2 Key Pair to allow SSH access to the instances. For more detail visit: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html'
     Type: AWS::EC2::KeyPair::KeyName
-    MinLength: 1
     ConstraintDescription: Must be the name of an existing EC2 KeyPair
   EnableVolumeEncryption:
     Description: 'Encrypt Environment instances volume with default AWS KMS key. Default: true'
@@ -356,10 +354,12 @@ Parameters:
   Certificate:
     Description: Amazon Resource Name (ARN) of an HTTPS Certificate, ignored if the selected protocol is HTTP (for the ALBProtocol parameter)
     Type: String
+    Default: ''
     AllowedPattern: '^(arn:aws:[a-z]+::[0-9]{12}:server-certificate/[a-zA-Z0-9-]*)?$'
     ConstraintDescription: 'Must be a valid Amazon Resource Name (ARN), for example: arn:aws:iam::123456789012:server-certificate/web-server-certificate'
   ServicePort:
     Description: 'The external Load Balancer listens to this port. Leave this field blank to use default ports: 80 for HTTP and 443 for HTTPS'
+    Default: ''
     Type: String
     AllowedPattern: '^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$'
     ConstraintDescription: Custom service port must be a number between 0 and 65535
@@ -389,14 +389,12 @@ Parameters:
     ConstraintDescription: Must be a valid EC2 instance type
   GatewaysMinSize:
     Description: The minimal number of Security Gateways
-    Type: Number
+    Type: String
     Default: 2
-    MinValue: 1
   GatewaysMaxSize:
     Description: The maximal number of Security Gateways
-    Type: Number
+    Type: String
     Default: 10
-    MinValue: 1
   GatewayVersion:
     Description: 'The version and license to install on the Security Gateways. Default: R80.40-PAYG-NGTP-GW. Allowed values: R80.40-BYOL-GW, R80.40-PAYG-NGTP-GW, R80.40-PAYG-NGTX-GW, R81-BYOL-GW, R81-PAYG-NGTP-GW, R81-PAYG-NGTX-GW'
     Type: String
@@ -476,11 +474,12 @@ Parameters:
       - 'true'
       - 'false'
   AdminCIDR:
-    Description: Allow web, SSH, and graphical clients only from this network to communicate with the Security Management Server
+    Description: Allow web, SSH, and graphical clients only from this CIDR IP Range to communicate with the Security Management Server (e.g. 127.0.0.1/32)
     Type: String
     AllowedPattern: '^(([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2]))?$'
   GatewaysAddresses:
-    Description: Allow gateways only from this network to communicate with the Security Management Server
+    Description: 'The CIDR IP range that is permitted to access the Security Management Server. Only gateways from this network can communicate with the Security Management Server. Default: 10.0.0.0/16'
+    Default: '10.0.0.0/16'
     Type: String
     AllowedPattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$'
   ServersDeploy:
@@ -505,21 +504,19 @@ Parameters:
     ConstraintDescription: Must be a valid EC2 instance type
   ServerAMI:
     Description: The Amazon Machine Image ID of a preconfigured web server (e.g. ami-0dc7dc63)
-    Type: String
-    AllowedPattern: '^(ami-(([0-9a-f]{8})|([0-9a-f]{17})))?$'
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: ''
     ConstraintDescription: Amazon Machine Image ID must be in the form ami-xxxxxxxx or ami-xxxxxxxxxxxxxxxxx
   #begin VPC (vpc.yaml)
   CreatePrivateSubnets:
-    Description: 'Set to false to create only public subnets. If false, the CIDR parameters
-      for ALL private subnets will be ignored. Default: true'
+    Description: 'Set to false to create only public subnets. If false, the CIDR parameters for ALL private subnets will be ignored. Default: true'
     Type: String
     Default: 'true'
     AllowedValues:
       - 'true'
       - 'false'
   CreateTgwSubnets:
-    Description: 'Set true for creating designated subnets for VPC TGW attachments. If false,
-      the CIDR parameters for the TGW subnets will be ignored. Default: false'
+    Description: 'Set true for creating designated subnets for VPC TGW attachments. If false, the CIDR parameters for the TGW subnets will be ignored. Default: false'
     Type: String
     Default: 'false'
     AllowedValues:
@@ -558,7 +555,7 @@ Parameters:
   #end SecurityGatewayStack (autoscale.yaml)
   #begin ManagementStack (management.yaml)
   AllocatePublicAddress:
-    Description: 'Allocate an elastic IP for the Management. Default: true'
+    Description: 'Allocate an elastic IP for the Management Server. Default: true'
     Type: String
     Default: 'true'
     AllowedValues:
@@ -609,7 +606,7 @@ Parameters:
     Default: 0.pool.ntp.org
     AllowedPattern: '[\.a-zA-Z0-9\-]*'
   ManagementHostname:
-    Description: '(optional). Default: mgmt-aws'
+    Description: 'Hostname of the Management Server (optional). Default: mgmt-aws'
     Type: String
     Default: mgmt-aws
     AllowedPattern: '^([A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?|)$'
@@ -621,12 +618,11 @@ Parameters:
     AllowedValues:
       - 'true'
       - 'false'
-  ManagementStackVolumeSize:
-    Description: 'EBS Volume size of the management server'
-    Type: Number
+  ManagementServerVolumeSize:
+    Description: 'EBS Volume size of the management server. Default 100. Minimum 100.'
+    Type: String
     Default: 100
-    MinValue: 100
-  ShellManagementStack:
+  ShellManagementServer:
     Description: 'Change the admin shell to enable advanced command line configuration. Default: /etc/cli.sh. Allowed values: /etc/cli.sh, /bin/bash, /bin/csh, /bin/tcsh'
     Type: String
     Default: /etc/cli.sh
@@ -658,16 +654,15 @@ Parameters:
       - private
       - public
   SecurityGatewayVolumeSize:
-    Description: 'EBS Volume size of the security gateway server'
-    Type: Number
+    Description: 'EBS Volume size of the security gateway server. Default 100. Minimum 100.'
+    Type: String
     Default: 100
-    MinValue: 100
   ELBClients:
     Description: 'Allow clients only from this network to communicate with the Web Servers. Default: 0.0.0.0/0'
     Type: String
     Default: 0.0.0.0/0
     AllowedPattern: '^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})$'
-  ShellSecurityGatewayStack:
+  ShellSecurityGatewayServer:
     Description: 'Change the admin shell to enable advanced command line configuration. Default: /etc/cli.sh. Allowed Values: /etc/cli.sh /bin/bash /bin/csh /bin/tcsh'
     Type: String
     Default: /etc/cli.sh
@@ -736,7 +731,9 @@ Conditions:
   #end VPC (vpc.yaml)
   #begin MainStack (qs-autoscale.template.yaml)
   DeployManagement: !Equals [!Ref ManagementDeploy, 'true']
-  DeployServers: !Equals [!Ref ServersDeploy, 'true']
+  DeployServers: !And
+    - !Equals [!Ref ServersDeploy, 'true']
+    - !Condition PrivateSubnets
   NLB: !Not [!Condition ALB]
   EncryptedProtocol: !Or
     - !And [!Condition ALB, !Equals [ALBProtocol, HTTPS]]
@@ -1816,15 +1813,16 @@ Resources:
       MaxSize: !Ref GatewaysMaxSize
       LoadBalancerNames: !If [CreateELB, [!Ref ElasticLoadBalancer], !Ref 'AWS::NoValue']
       TargetGroupARNs: !If [ProvidedTargetGroups, !Split [',', !Ref GatewaysTargetGroups], !Ref 'AWS::NoValue']
-      NotificationConfiguration: !If
-        - ProvidedAdminEmail
-        - TopicARN: !Ref NotificationTopicSecurityGatewayStack
-          NotificationTypes:
-            - autoscaling:EC2_INSTANCE_LAUNCH
-            - autoscaling:EC2_INSTANCE_LAUNCH_ERROR
-            - autoscaling:EC2_INSTANCE_TERMINATE
-            - autoscaling:EC2_INSTANCE_TERMINATE_ERROR
-        - !Ref 'AWS::NoValue'
+      NotificationConfigurations: 
+        - !If
+          - ProvidedAdminEmail
+          - TopicARN: !Ref NotificationTopicSecurityGatewayStack
+            NotificationTypes:
+              - autoscaling:EC2_INSTANCE_LAUNCH
+              - autoscaling:EC2_INSTANCE_LAUNCH_ERROR
+              - autoscaling:EC2_INSTANCE_TERMINATE
+              - autoscaling:EC2_INSTANCE_TERMINATE_ERROR
+          - !Ref 'AWS::NoValue'
       Tags:
         - Key: Name
           Value: !Sub '${ProvisionTag}-security-gateway'
@@ -1841,7 +1839,14 @@ Resources:
     Properties:
       AssociatePublicIpAddress: true
       KeyName: !Ref KeyName
-      ImageId: !FindInMap [RegionMap ,!Ref 'AWS::Region', Fn::FindInMap: [ConverterMap, !Ref GatewayVersion, Value]]
+      ImageId:
+        Fn::FindInMap:
+          - RegionMap
+          - Ref: AWS::Region
+          - Fn::FindInMap:
+              - ConverterMap
+              - Ref: GatewayVersion
+              - Value
       SecurityGroups:
         - !Ref PermissiveSecurityGroup
       InstanceType: !Ref GatewayInstanceType
@@ -1864,7 +1869,7 @@ Resources:
             - 'exec 1>>${logfile} 2>>${logfile}'
             - 'echo -e "\nStarting user-data\n"'
             - 'echo "Setting up parameters"'
-            - !Sub 'pwd_hash=''${GatewayPasswordHash}'' ; shell=${ShellSecurityGatewayStack} ; allow_info=${AllowUploadDownload} ; cw=${CloudWatch} ; eic=${EnableInstanceConnect}'
+            - !Sub 'pwd_hash=''${GatewayPasswordHash}'' ; shell=${ShellSecurityGatewayServer} ; allow_info=${AllowUploadDownload} ; cw=${CloudWatch} ; eic=${EnableInstanceConnect}'
             - !Join ['', ['sic="$(echo ', 'Fn::Base64': !Ref GatewaySICKey, ' | base64 -d)"']]
             - !Join 
               - ''
@@ -2163,7 +2168,14 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub '${ProvisionTag}-management'
-      ImageId: !FindInMap [RegionMap ,!Ref 'AWS::Region', Fn::FindInMap: [ConverterMap, !Ref ManagementVersion, Value]]
+      ImageId:
+        Fn::FindInMap:
+          - RegionMap
+          - Ref: AWS::Region
+          - Fn::FindInMap:
+              - ConverterMap
+              - Ref: ManagementVersion
+              - Value
       InstanceType: !Ref ManagementInstanceType
       IamInstanceProfile: !If [UseRole, !Ref InstanceProfile, !Ref 'AWS::NoValue']
       KeyName: !Ref KeyName
@@ -2180,7 +2192,7 @@ Resources:
           Ebs:
             Encrypted: !Ref EnableVolumeEncryption
             VolumeType: gp2
-            VolumeSize: !Ref ManagementStackVolumeSize
+            VolumeSize: !Ref ManagementServerVolumeSize
       UserData:
         'Fn::Base64':
           !Join
@@ -2213,7 +2225,7 @@ Resources:
             - '}'
             - 'echo -e "\nStarting user-data\n"'
             - 'echo "Setting up parameters"'
-            - !Sub 'pwd_hash=''${ManagementPasswordHash}'' ; shell=${ShellManagementStack} ; allow_info=${AllowUploadDownload} ; hostname=${ManagementHostname} ; primary=${PrimaryManagement} ; eic=${EnableInstanceConnect} ; admin_subnet=${AdminCIDR} ; eip=${AllocatePublicAddress} ; ntp1=${NTPPrimary} ; ntp2=${NTPSecondary}'
+            - !Sub 'pwd_hash=''${ManagementPasswordHash}'' ; shell=${ShellManagementServer} ; allow_info=${AllowUploadDownload} ; hostname=${ManagementHostname} ; primary=${PrimaryManagement} ; eic=${EnableInstanceConnect} ; admin_subnet=${AdminCIDR} ; eip=${AllocatePublicAddress} ; ntp1=${NTPPrimary} ; ntp2=${NTPSecondary}'
             - !If [EIP, !Sub 'wait_handle=''${ManagementReadyHandle}''',!Ref 'AWS::NoValue']
             - !If [NoSIC, 'sic=""', !Join ['', ['sic="$(echo ', 'Fn::Base64': !Ref ManagementSICKey, ' | base64 -d)"']]]
             - !If [ManageOverInternetAndEIP, 'pub_mgmt=true', 'pub_mgmt=false']
@@ -2420,15 +2432,16 @@ Resources:
       MinSize: !Ref ServersMinSize
       MaxSize: !Ref ServersMaxSize
       TargetGroupARNs: !If [ProvidedTargetGroupsServersStack, !Split [',', !Ref ServersTargetGroups], !Ref 'AWS::NoValue']
-      NotificationConfiguration: !If
-        - ProvidedAdminEmail
-        - TopicARN: !Ref NotificationTopic
-          NotificationTypes:
-            - autoscaling:EC2_INSTANCE_LAUNCH
-            - autoscaling:EC2_INSTANCE_LAUNCH_ERROR
-            - autoscaling:EC2_INSTANCE_TERMINATE
-            - autoscaling:EC2_INSTANCE_TERMINATE_ERROR
-        - !Ref 'AWS::NoValue'
+      NotificationConfigurations: 
+        - !If
+          - ProvidedAdminEmail
+          - TopicARN: !Ref NotificationTopic
+            NotificationTypes:
+              - autoscaling:EC2_INSTANCE_LAUNCH
+              - autoscaling:EC2_INSTANCE_LAUNCH_ERROR
+              - autoscaling:EC2_INSTANCE_TERMINATE
+              - autoscaling:EC2_INSTANCE_TERMINATE_ERROR
+          - !Ref 'AWS::NoValue'
       Tags:
         - Key: Name
           Value: !Ref ServerName


### PR DESCRIPTION
Converted several parameters numeric type to string to address issue due to module passing incorrect types to resource properties if type is numeric.  Fixed issue with FindInMap syntax at 2 resources' ImageId property (yaml validator failed during submit).  Fixed invalid property NotificationConfiguration (changed to NotificationConfigurations).  Fixed logic warnings in PrivateSubnets conditions.  Fixed MinValue warnings, several parameters.  Changed ServerAMI parameter from string to AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>.  Changed various parameter descriptions to be clearer. Added default values for several parameters so they weren't required. Changed a few parameter names to be more clear

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
